### PR TITLE
Permission change to .../uploads/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN chown -R www-data:www-data /etc/apache2/sites-enabled/
 
 RUN chown -R www-data:www-data /var/www/phishing-frenzy/public/uploads/
 
+RUN chmod -R 755 /var/www/phishing-frenzy/public/uploads/
+
 ADD /startup.sh /startup.sh
 
 RUN chmod +x /startup.sh


### PR DESCRIPTION
Found that I was getting errors when uploading to templates with the new docker image. In raising the issue I found out that it had to do with the permissions and in reviewing the DockerFile I noticed the " chmod -R 755 /var/www/phishing-frenzy/public/uploads/ " step missing.