### PR TITLE
Update the referenced Passenger version (temporary fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN touch /etc/apache2/httpd.conf
 RUN chown www-data:www-data /etc/apache2/httpd.conf
 
 RUN gem install --no-rdoc --no-ri rails
-RUN gem install --no-rdoc --no-ri passenger
+RUN gem install --no-rdoc --no-ri passenger -v 5.0.6
 
 RUN passenger-install-apache2-module
 

--- a/apache2.conf
+++ b/apache2.conf
@@ -222,8 +222,8 @@ IncludeOptional sites-enabled/*.conf
 Include pf.conf
 Include httpd.conf
 
-LoadModule passenger_module /var/lib/gems/2.1.0/gems/passenger-4.0.57/buildout/apache2/mod_passenger.so
+LoadModule passenger_module /var/lib/gems/2.1.0/gems/passenger-5.0.6/buildout/apache2/mod_passenger.so
 <IfModule mod_passenger.c>
-  PassengerRoot /var/lib/gems/2.1.0/gems/passenger-4.0.57
+  PassengerRoot /var/lib/gems/2.1.0/gems/passenger-5.0.6
   PassengerDefaultRuby /usr/bin/ruby2.1
 </IfModule>


### PR DESCRIPTION
Currently, the version of Passenger that this image tries to install is 5.0.6, which means you run into errors with the apache config where it's referencing a 4.x version of the gem. I've updated this to 5.0.6 as a temporary measure, but there is likely a more clever way to get the correct version and always reference the proper version. Since the PhishingFrenzy tutorial references this repo directly, it'd be nice to have that working for now and then come up with a better long term fix for the future.